### PR TITLE
Copy bank data to clipboard, formatted as either CSV or JSON

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.17'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/spudjb/bankvalue/BankValueConfig.java
+++ b/src/main/java/spudjb/bankvalue/BankValueConfig.java
@@ -1,0 +1,70 @@
+package spudjb.bankvalue;
+
+import net.runelite.client.config.*;
+import spudjb.bankvalue.config.DataFormatSetting;
+
+@ConfigGroup("bank-value")
+public interface BankValueConfig extends Config {
+	@ConfigSection(
+			name = "Export bank data",
+			description = "Export your bank data to CSV or JSON via your clipboard",
+			position = 0
+	)
+	String exportBankData = "exportBankData";
+
+	@ConfigItem(
+			position = 0,
+			keyName = "showExportBankButton",
+			name = "Show export bank button",
+			description = "Show the export bank data button",
+			section = exportBankData
+	)
+	default boolean showExportBankButton()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 2,
+			keyName = "hideUnderValue",
+			name = "Hide under value",
+			description = "Remove items under the specified value"
+	)
+	default int hideUnderValue()
+	{
+		return 0;
+	}
+
+	@ConfigItem(
+			position = 3,
+			keyName = "dataOrder",
+			name = "Order of data",
+			description = "Change the order of the exported data, or remove entries entirely. E.G.: name,value,quantity"
+	)
+	default String dataOrder()
+	{
+		return "name,itemid,quantity,value";
+	}
+
+	@ConfigItem(
+			position = 3,
+			keyName = "showDataTitles",
+			name = "Add titles to export",
+			description = "Add titles to your CSV export, e.g. Name, Item ID, Quantity, Value (only for CSV export)"
+	)
+	default boolean showDataTitles()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			position = 4,
+			keyName = "dataFormat",
+			name = "Data Format",
+			description = "Choose how to format your exported data"
+	)
+	default DataFormatSetting dataFormat()
+	{
+		return DataFormatSetting.CSV;
+	}
+}

--- a/src/main/java/spudjb/bankvalue/BankValuePanel.java
+++ b/src/main/java/spudjb/bankvalue/BankValuePanel.java
@@ -24,48 +24,56 @@
  */
 package spudjb.bankvalue;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.GridLayout;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+
+import com.google.gson.*;
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
+import spudjb.bankvalue.config.DataFormatSetting;
 
 @Slf4j
 class BankValuePanel extends PluginPanel
 {
+	private final BankValuePlugin plugin;
+	private final ConfigManager configManager;
+	private final BankValueConfig config;
+	private Gson gson;
 	private static final Color ODD_ROW = new Color(44, 44, 44);
-
 	private final JPanel listContainer = new JPanel();
-
 	private BankValueTableHeader countHeader;
 	private BankValueTableHeader valueHeader;
 	private BankValueTableHeader nameHeader;
-
 	private SortOrder orderIndex = SortOrder.VALUE;
 	private boolean ascendingOrder = false;
-
 	private ArrayList<BankValueTableRow> rows = new ArrayList<>();
-	private BankValuePlugin plugin;
 
-	BankValuePanel(BankValuePlugin plugin)
+	BankValuePanel(BankValuePlugin plugin, BankValueConfig config, ConfigManager configManager)
 	{
 		this.plugin = plugin;
+		this.config = config;
+		this.configManager = configManager;
 
 		setBorder(null);
 		setLayout(new DynamicGridLayout(0, 1));
 
 		JPanel headerContainer = buildHeader();
+		JPanel exportContainer = buildExportPanel();
 
 		listContainer.setLayout(new GridLayout(0, 1));
+
+		if (config.showExportBankButton()) {
+			add(exportContainer);
+		}
 
 		add(headerContainer);
 		add(listContainer);
@@ -138,6 +146,39 @@ class BankValuePanel extends PluginPanel
 		updateList();
 	}
 
+	private void exportToClipboard()
+	{
+		if (null == plugin.cachedItems) return;
+		Object result;
+
+		if (config.dataFormat() == DataFormatSetting.JSON) {
+			result = new JsonArray();
+
+			for (CachedItem item : plugin.cachedItems) {
+				if (config.hideUnderValue() > item.getValue()) {
+					continue;
+				}
+				((JsonArray) result).add(createJsonObject(item.getName(), item.getId(), item.getQuantity(), item.getValue() * item.getQuantity()));
+			}
+		} else {
+			result = new StringBuilder();
+
+			if (config.showDataTitles()) {
+				((StringBuilder) result).append(addCSVLine("Item Name", "Item ID", "Quantity", "Value"));
+			}
+
+			for (CachedItem item : plugin.cachedItems) {
+				if (config.hideUnderValue() > item.getValue()) {
+					continue;
+				}
+				((StringBuilder) result).append(addCSVLine(item.getName(), item.getId(), item.getQuantity(), item.getValue() * item.getQuantity()));
+			}
+		}
+
+		Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+		clipboard.setContents(new StringSelection(result.toString()), null);
+	}
+
 	/**
 	 * Builds the entire table header.
 	 */
@@ -205,6 +246,93 @@ class BankValuePanel extends PluginPanel
 		return header;
 	}
 
+	private JPanel buildExportPanel()
+	{
+		JPanel exportPanel = new JPanel(new BorderLayout(1, 0));
+		JPanel buttonPanel = new JPanel(new BorderLayout(0, 1));
+		final JButton exportToClipboardButton = new JButton();
+
+		exportPanel.setBorder(BorderFactory.createEmptyBorder(5, 1, 5, 1));
+		exportToClipboardButton.setText("Copy Bank Data to clipboard");
+		exportToClipboardButton.setToolTipText("Export bank as CSV data, copied to your clipboard. Configure in settings");
+		exportToClipboardButton.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				exportToClipboardButton.setForeground(ColorScheme.BRAND_ORANGE);
+				exportToClipboardButton.setText("Copy Bank Data to clipboard");
+			}
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				exportToClipboardButton.setForeground(ColorScheme.LIGHT_GRAY_COLOR);
+			}
+			@Override
+			public void mouseClicked(MouseEvent mouseEvent)
+			{
+				exportToClipboard();
+				exportToClipboardButton.setText("Copied!");
+			}
+		});
+
+		buttonPanel.add(exportToClipboardButton, BorderLayout.CENTER);
+		exportPanel.add(buttonPanel, BorderLayout.CENTER);
+		return exportPanel;
+	}
+
+	private <T> StringBuilder addCSVLine(String nameVal, T idVal, T quantityVal, T gpVal)
+	{
+		String[] order = config.dataOrder().split(",");
+		StringBuilder newLine = new StringBuilder();
+
+		for (int i = 0; i < order.length; i++) {
+			switch(order[i]) {
+				case "name":
+					newLine.append(nameVal);
+					break;
+				case "itemid":
+					newLine.append(idVal);
+					break;
+				case "quantity":
+					newLine.append(quantityVal);
+					break;
+				case "value":
+					newLine.append(gpVal);
+			}
+
+			if (i != order.length - 1) {
+				newLine.append(',');
+			}
+		}
+		newLine.append('\n');
+		return newLine;
+	}
+
+	private <T> JsonObject createJsonObject(String nameVal, T idVal, T quantityVal, T gpVal)
+	{
+		String[] order = config.dataOrder().split(",");
+		JsonObject item = new JsonObject();
+		Gson gson = new GsonBuilder().create();
+
+		for (String property : order) {
+			switch (property) {
+				case "itemid":
+					item.add("id", gson.toJsonTree(idVal));
+					break;
+				case "name":
+					item.add("name", gson.toJsonTree(nameVal));
+					break;
+				case "quantity":
+					item.add("quantity", gson.toJsonTree(quantityVal));
+					break;
+				case "value":
+					item.add("value", gson.toJsonTree(gpVal));
+			}
+		}
+		return item;
+	}
+
 	/**
 	 * Builds a table row, that displays the bank's information.
 	 */
@@ -225,3 +353,4 @@ class BankValuePanel extends PluginPanel
 		NAME
 	}
 }
+

--- a/src/main/java/spudjb/bankvalue/BankValuePanel.java
+++ b/src/main/java/spudjb/bankvalue/BankValuePanel.java
@@ -254,7 +254,7 @@ class BankValuePanel extends PluginPanel
 
 		exportPanel.setBorder(BorderFactory.createEmptyBorder(5, 1, 5, 1));
 		exportToClipboardButton.setText("Copy Bank Data to clipboard");
-		exportToClipboardButton.setToolTipText("Export bank as CSV data, copied to your clipboard. Configure in settings");
+		exportToClipboardButton.setToolTipText("Export your bank data, copied to your clipboard. Configure in settings");
 		exportToClipboardButton.addMouseListener(new MouseAdapter()
 		{
 			@Override

--- a/src/main/java/spudjb/bankvalue/BankValuePanel.java
+++ b/src/main/java/spudjb/bankvalue/BankValuePanel.java
@@ -155,7 +155,7 @@ class BankValuePanel extends PluginPanel
 			result = new JsonArray();
 
 			for (CachedItem item : plugin.cachedItems) {
-				if (config.hideUnderValue() > item.getValue()) {
+				if (config.hideUnderValue() > (item.getValue() * item.getQuantity())) {
 					continue;
 				}
 				((JsonArray) result).add(createJsonObject(item.getName(), item.getId(), item.getQuantity(), item.getValue() * item.getQuantity()));
@@ -168,7 +168,7 @@ class BankValuePanel extends PluginPanel
 			}
 
 			for (CachedItem item : plugin.cachedItems) {
-				if (config.hideUnderValue() > item.getValue()) {
+				if (config.hideUnderValue() > (item.getValue() * item.getQuantity())) {
 					continue;
 				}
 				((StringBuilder) result).append(addCSVLine(item.getName(), item.getId(), item.getQuantity(), item.getValue() * item.getQuantity()));

--- a/src/main/java/spudjb/bankvalue/config/DataFormatSetting.java
+++ b/src/main/java/spudjb/bankvalue/config/DataFormatSetting.java
@@ -1,0 +1,6 @@
+package spudjb.bankvalue.config;
+
+public enum DataFormatSetting
+{
+	CSV,JSON
+}


### PR DESCRIPTION
Added a Copy Bank Data to clipboard button that exports your bank in CSV/JSON format.

![image](https://github.com/spudjb/runelite-bank-value/assets/10326958/4ba18a82-e95d-4dd6-a396-4089e7ad2d51) 

![image](https://github.com/spudjb/runelite-bank-value/assets/10326958/45c0cdaa-1459-46ad-9edf-f14c3fc93bb8)

Includes options for exporting bank data: disable the button, change the data format, multiple filtering options and more.

![image](https://github.com/spudjb/runelite-bank-value/assets/10326958/de39713a-9ef5-4c6a-a0ac-74e9e582d8de)


Examples of data exports:

CSV:
![image](https://github.com/spudjb/runelite-bank-value/assets/10326958/330d5715-0eed-4397-88f7-da40d7a3bf7f)

JSON:
![image](https://github.com/spudjb/runelite-bank-value/assets/10326958/ee381de8-2d7c-4b9f-81af-3cde7cb4a911)
